### PR TITLE
Fix error when external contributor pushes twice (updating the comment)

### DIFF
--- a/coverage_comment/github.py
+++ b/coverage_comment/github.py
@@ -124,7 +124,10 @@ def post_comment(
     for comment in issue_comments_path.get():
         if comment.user.login == me and marker in comment.body:
             log.info("Update previous comment")
-            comments_path(comment.id).patch(body=contents)
+            try:
+                comments_path(comment.id).patch(body=contents)
+            except github_client.Forbidden as exc:
+                raise CannotPostComment from exc
             break
     else:
         log.info("Adding new comment")

--- a/tests/integration/test_github.py
+++ b/tests/integration/test_github.py
@@ -233,6 +233,28 @@ def test_post_comment__update(gh, session, get_logs):
     assert get_logs("INFO", "Update previous comment")
 
 
+def test_post_comment__update_error(gh, session):
+    comment = {
+        "user": {"login": "foo"},
+        "body": "Hey! Hi! How are you? marker",
+        "id": 456,
+    }
+    session.register("GET", "/repos/foo/bar/issues/123/comments")(json=[comment])
+    session.register(
+        "PATCH", "/repos/foo/bar/issues/comments/456", json={"body": "hi!"}
+    )(status_code=403)
+
+    with pytest.raises(github.CannotPostComment):
+        github.post_comment(
+            github=gh,
+            me="foo",
+            repository="foo/bar",
+            pr_number=123,
+            contents="hi!",
+            marker="marker",
+        )
+
+
 def test_set_output(capsys):
     github.set_output(foo=True)
     captured = capsys.readouterr()


### PR DESCRIPTION
Action was broken when external contributor did something that triggered the action to update an existing comment (such as pushing new commits in an already open PR)