### PR TITLE
Fix examples in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,7 +271,7 @@ In this second example, we replace the whole comment by something much shorter w
 coverage (percentage) of the whole project from the PR build:
 
 ```jinja2
-Coverage: {{ coverage.info.percent_covered | pct }}
+Coverage: {{ coverage.info.percent_covered | pct }}{{ marker }}
 ```
 
 # Other topics

--- a/README.md
+++ b/README.md
@@ -230,7 +230,7 @@ jobs:
     COMMENT_FILENAME: python-coverage-comment-action.txt
 
     # An alternative template for the comment for pull requests. See details below.
-    COMMENT_TEMPLATE: The coverage rate is `{{ coverage.info.percent_covered | pct }}{{ marker }}`
+    COMMENT_TEMPLATE: The coverage rate is `{{ coverage.info.percent_covered | pct }}`{{ marker }}
 ```
 
 ## Overriding the template

--- a/README.md
+++ b/README.md
@@ -271,7 +271,7 @@ In this second example, we replace the whole comment by something much shorter w
 coverage (percentage) of the whole project from the PR build:
 
 ```jinja2
-Coverage: {{ coverage.info.percent_covered | pct }}{{ marker }}
+"Coverage: {{ coverage.info.percent_covered | pct }}{{ marker }}"
 ```
 
 # Other topics


### PR DESCRIPTION
I've been messing around a bit with `COMMENT_TEMPLATE` in my private repository and noticed that the examples in the `README` don't all work or cause unwanted effects (visible marker).

Regarding the quotes in the last commit: when I tried to use the example without quotes, Github did not interpret the input as a string, but tried to process it somehow differently. While this is not a problem with some other examples, it might make sense to make all examples with quotes and add a note to that effect, but that's their decision.