### PR TITLE
Last update to v2, new developments will be on v3

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -33,7 +33,7 @@ jobs:
         with:
           images: ewjoachim/python-coverage-comment-action
           flavor: |
-            latest=true
+            latest=false
 
       - name: Build and push Docker image
         uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc

--- a/README.md
+++ b/README.md
@@ -2,12 +2,20 @@
 
 ![Coverage badge](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/wiki/ewjoachim/python-coverage-comment-action/python-coverage-comment-action-badge.json)
 
+## Disclaimer
+
+You're looking at the v2 version of this GitHub Action. The
+[v3+](https://github.com/ewjoachim/python-coverage-comment-action) adds
+significant improvements, such as not needing the wiki anymore, and working on
+private repos. You're free to stay on v2, but we'll most likely not offer any
+kind of updates to it.
+
 ## Presentation
 
 Publish diff coverage report as PR comment, and create a coverage badge to
 display on the readme.
 
-See example at: https://github.com/ewjoachim/python-coverage-comment-action-example
+See example at: https://github.com/ewjoachim/python-coverage-comment-action-example/tree/v2
 
 ## What does it do?
 
@@ -34,7 +42,7 @@ rate and create a small JSON file that will be stored on the repository's wiki.
 This file will then have a stable URL, which means that if your repository is public,
 you can create a [shields.io](https://shields.io/endpoint) badge from it.
 
-See: https://github.com/ewjoachim/python-coverage-comment-action-example
+See: https://github.com/ewjoachim/python-coverage-comment-action-example/tree/v2
 
 ## Usage
 

--- a/action.yml
+++ b/action.yml
@@ -65,7 +65,7 @@ outputs:
 runs:
   using: docker
   # image: Dockerfile
-  image: docker://ewjoachim/python-coverage-comment-action:latest
+  image: docker://ewjoachim/python-coverage-comment-action:v2
   env:
     GITHUB_TOKEN: ${{ inputs.GITHUB_TOKEN }}
     GITHUB_PR_RUN_ID: ${{ inputs.GITHUB_PR_RUN_ID }}


### PR DESCRIPTION
@kieferro Please feel free to tell me if I forgot something important (or not important) :)

I think the plan is:
- Fork the v3 branch ([done already](https://github.com/ewjoachim/python-coverage-comment-action/tree/v3))
- On v3, have Docker don't push the `latest` docker tag.
- Merge this
- Then switch v3 as the default branch
- Then merge #33 
- Then work on the end-to-end tests on v3
- Then maybe release v3.0.0 and re-enable latest