### PR TITLE
Disable pushing the latest branch

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -33,7 +33,7 @@ jobs:
         with:
           images: ewjoachim/python-coverage-comment-action
           flavor: |
-            latest=true
+            latest=false
 
       - name: Build and push Docker image
         uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc


### PR DESCRIPTION
Most of our users will stay on this version until we start pushing latest again. By that time, v2 will not use the "latest" docker tag but the v2 tag.

(note: this is targetting the v3 branch)

Refs #36 