### PR TITLE
fix/white-space 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,17 +12,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: "3.10"
 
       - name: Install Poetry
         run: |
-          curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python -
-          echo "$HOME/.poetry/bin" >> $GITHUB_PATH
+          pipx install poetry
 
       - name: Poetry caches
         uses: actions/cache@v2

--- a/coverage_comment/default.md.j2
+++ b/coverage_comment/default.md.j2
@@ -35,8 +35,7 @@ The branch rate is `{{ (coverage.info.covered_branches / coverage.info.num_branc
 {%if diff_coverage.files -%}
 <details>
 <summary>{% block coverage_by_file_summary_wording -%}Diff Coverage details (click to unfold){% endblock coverage_by_file_summary_wording -%}</summary>
-
-{% for filename, diff_file_coverage in diff_coverage.files.items() -%}
+{% for filename, diff_file_coverage in diff_coverage.files.items() %}
 {% block coverage_single_file scoped -%}
 {% block coverage_single_file_title scoped %}### {{ filename }}{% endblock coverage_single_file_title %}
 {% block diff_coverage_single_file_wording scoped -%}

--- a/coverage_comment/default.md.j2
+++ b/coverage_comment/default.md.j2
@@ -35,19 +35,19 @@ The branch rate is `{{ (coverage.info.covered_branches / coverage.info.num_branc
 {%if diff_coverage.files -%}
 <details>
 <summary>{% block coverage_by_file_summary_wording -%}Diff Coverage details (click to unfold){% endblock coverage_by_file_summary_wording -%}</summary>
-{% for filename, diff_file_coverage in diff_coverage.files.items() %}
-{% block coverage_single_file scoped -%}
+{% for filename, diff_file_coverage in diff_coverage.files.items() -%}
+{% block coverage_single_file scoped %}
 {% block coverage_single_file_title scoped %}### {{ filename }}{% endblock coverage_single_file_title %}
 {% block diff_coverage_single_file_wording scoped -%}
 `{{ diff_file_coverage.percent_covered | pct }}` of new lines are covered (`{{ coverage.files[filename].info.percent_covered | pct }}` of the complete file).
 {%- endblock diff_coverage_single_file_wording %}
-{%- if diff_file_coverage.violation_lines %}
+{%- if diff_file_coverage.violation_lines -%}
 {% block single_file_missing_lines_wording scoped -%}
 {% set separator = joiner(", ") %}
 Missing lines: {% for line in diff_file_coverage.violation_lines %}{{ separator() }}`{{ line }}`{% endfor %}
 {%- endblock single_file_missing_lines_wording %}
-{% endif -%}
-{%- endblock coverage_single_file -%}
+{%- endif %}
+{% endblock coverage_single_file -%}
 {%- endfor %}
 </details>
 {%- endif %}

--- a/tests/unit/test_template.py
+++ b/tests/unit/test_template.py
@@ -58,7 +58,6 @@ The branch rate is `50%`.
 
 ### codebase/code.py
 `80%` of new lines are covered (`75%` of the complete file).
-
 Missing lines: `7`, `9`
 
 </details>
@@ -187,7 +186,6 @@ The coverage rate is `75%`.
 
 ### codebase/code.py
 `80%` of new lines are covered (`75%` of the complete file).
-
 Missing lines: `7`, `9`
 
 </details>

--- a/tests/unit/test_template.py
+++ b/tests/unit/test_template.py
@@ -1,6 +1,8 @@
+import datetime
+
 import pytest
 
-from coverage_comment import template
+from coverage_comment import coverage, template
 
 
 def test_get_markdown_comment(coverage_obj, diff_coverage_obj):
@@ -58,6 +60,110 @@ The branch rate is `50%`.
 `80%` of new lines are covered (`75%` of the complete file).
 
 Missing lines: `7`, `9`
+
+</details>
+<!-- This comment was produced by python-coverage-comment-action -->"""
+    assert result == expected
+
+
+def test_template_full():
+
+    cov = coverage.Coverage(
+        meta=coverage.CoverageMetadata(
+            version="1.2.3",
+            timestamp=datetime.datetime(2000, 1, 1),
+            branch_coverage=True,
+            show_contexts=False,
+        ),
+        info=coverage.CoverageInfo(
+            covered_lines=6,
+            num_statements=6,
+            percent_covered=1.0,
+            missing_lines=0,
+            excluded_lines=0,
+            num_branches=2,
+            num_partial_branches=0,
+            covered_branches=2,
+            missing_branches=0,
+        ),
+        files={
+            "codebase/code.py": coverage.FileCoverage(
+                path="codebase/code.py",
+                executed_lines=[1, 2, 5, 6, 9],
+                missing_lines=[],
+                excluded_lines=[],
+                info=coverage.CoverageInfo(
+                    covered_lines=5,
+                    num_statements=6,
+                    percent_covered=5 / 6,
+                    missing_lines=1,
+                    excluded_lines=0,
+                    num_branches=2,
+                    num_partial_branches=0,
+                    covered_branches=2,
+                    missing_branches=0,
+                ),
+            ),
+            "codebase/other.py": coverage.FileCoverage(
+                path="codebase/other.py",
+                executed_lines=[1, 2, 3],
+                missing_lines=[],
+                excluded_lines=[],
+                info=coverage.CoverageInfo(
+                    covered_lines=6,
+                    num_statements=6,
+                    percent_covered=1.0,
+                    missing_lines=0,
+                    excluded_lines=0,
+                    num_branches=2,
+                    num_partial_branches=0,
+                    covered_branches=2,
+                    missing_branches=0,
+                ),
+            ),
+        },
+    )
+
+    diff_cov = coverage.DiffCoverage(
+        total_num_lines=6,
+        total_num_violations=0,
+        total_percent_covered=1.0,
+        num_changed_lines=39,
+        files={
+            "codebase/code.py": coverage.FileDiffCoverage(
+                path="codebase/code.py",
+                percent_covered=1 / 2,
+                violation_lines=[5],
+            ),
+            "codebase/other.py": coverage.FileDiffCoverage(
+                path="codebase/other.py",
+                percent_covered=1,
+                violation_lines=[],
+            ),
+        },
+    )
+
+    result = template.get_markdown_comment(
+        coverage=cov,
+        diff_coverage=diff_cov,
+        previous_coverage_rate=1.0,
+        base_template=template.read_template_file(),
+    )
+    expected = """## Coverage report
+The coverage rate went from `100%` to `100%` :arrow_right:
+The branch rate is `100%`.
+
+`100%` of new lines are covered.
+
+<details>
+<summary>Diff Coverage details (click to unfold)</summary>
+
+### codebase/code.py
+`50%` of new lines are covered (`83%` of the complete file).
+Missing lines: `5`
+
+### codebase/other.py
+`100%` of new lines are covered (`100%` of the complete file).
 
 </details>
 <!-- This comment was produced by python-coverage-comment-action -->"""


### PR DESCRIPTION
for `100%` file coverage ( when there is no violation_lines ), there is a issue with whitespacing, the file title following, are concatenated with the prev violating_lines block.

This PR aims to solve that.