### PR TITLE
Make end-to-end tests on PR (running only for admins) use the current commit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,7 @@ jobs:
         env:
           COVERAGE_COMMENT_E2E_GITHUB_TOKEN_USER_1: ${{ secrets.COVERAGE_COMMENT_E2E_GITHUB_TOKEN_USER_1 }}
           COVERAGE_COMMENT_E2E_GITHUB_TOKEN_USER_2: ${{ secrets.COVERAGE_COMMENT_E2E_GITHUB_TOKEN_USER_2 }}
+          COVERAGE_COMMENT_E2E_ACTION_REF: ${{ github.sha }}
 
       - name: Coverage comment
         id: coverage_comment

--- a/end_to_end_tests_repo/.github/workflows/ci.yml
+++ b/end_to_end_tests_repo/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Coverage comment
         id: coverage_comment
-        uses: ewjoachim/python-coverage-comment-action@v3
+        uses: ewjoachim/python-coverage-comment-action@__ACTION_REF__
         with:
           GITHUB_TOKEN: ${{ github.token }}
           VERBOSE: "true"

--- a/end_to_end_tests_repo/.github/workflows/coverage-comment.yml
+++ b/end_to_end_tests_repo/.github/workflows/coverage-comment.yml
@@ -13,7 +13,7 @@ jobs:
     if: github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success'
     steps:
       - name: Post comment
-        uses: ewjoachim/python-coverage-comment-action@v3
+        uses: ewjoachim/python-coverage-comment-action@__ACTION_REF__
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_PR_RUN_ID: ${{ github.event.workflow_run.id }}

--- a/tests/end_to_end/conftest.py
+++ b/tests/end_to_end/conftest.py
@@ -79,6 +79,11 @@ def token_other():
 
 
 @pytest.fixture
+def action_ref():
+    return os.environ.get("COVERAGE_COMMENT_E2E_ACTION_REF", "v3")
+
+
+@pytest.fixture
 def _gh(call, gh_config_dir):
     def gh(*args, token, json=False):
         stdout = call(
@@ -161,7 +166,7 @@ def gh_other_username(gh_other):
 
 
 @pytest.fixture
-def git_repo(cd, git):
+def git_repo(cd, git, action_ref):
     with cd("repo") as repo:
         git("init", "-b", "main")
         shutil.copytree(
@@ -169,6 +174,11 @@ def git_repo(cd, git):
             repo,
             dirs_exist_ok=True,
         )
+        # Rewrite the specific version of the action we run in the workflow files.
+        for file in (repo / ".github/workflows").iterdir():
+            file: pathlib.Path
+            file.write_text(file.read_text().replace("__ACTION_REF__", action_ref))
+
         git("add", ".")
         git("commit", "-m", "initial commit")
         yield repo


### PR DESCRIPTION
When GitHub launches the end-to-end tests of the actions in the CI, it will now ensure that the version of of the action that runs in the end-to-end repo is the one from the PR, so we really test the action.